### PR TITLE
Multilingual RAG

### DIFF
--- a/rag.py
+++ b/rag.py
@@ -1,0 +1,88 @@
+import weaviate, os, json
+import openai
+from dotenv import load_dotenv, find_dotenv
+_ = load_dotenv(find_dotenv())
+
+def json_print(data):
+    print(json.dumps(data, indent=2))
+
+# Connect to Weaviate Cloud using API key
+auth_config = weaviate.AuthApiKey(api_key=os.getenv("WEAVIATE_API_KEY"))
+client = weaviate.connect_to_cloud(
+    url=os.getenv("WEAVIATE_URL"),
+    auth_client_secret=auth_config,
+    additional_headers={"X-OpenAI-Api-Key": os.getenv("OPENAI_API_KEY")}
+)
+print("Weaviate client connected successfully.")
+
+client.is_ready()
+
+print(json.dumps(client.query.aggregate("Wikipedia").with_meta_count().do(), indent=2)) # prints the number of vectors stored in this database
+
+# Query the Wikipedia collection for vacation spots in California
+response = (client.query
+            .get("Wikipedia",['text','title','url','views','lang'])
+            .with_near_text({"concepts": "Vacation spots in california"})
+            .with_limit(5)
+            .do()
+           )
+
+json_print(response)
+
+# multilingual query for vacation spots in California
+response = (client.query
+            .get("Wikipedia",['text','title','url','views','lang'])
+            .with_near_text({"concepts": "Miejsca na wakacje w Kalifornii"})
+            .with_where({
+                "path" : ['lang'],
+                "operator" : "Equal",
+                "valueString":'en'
+            })
+            .with_limit(3)
+            .do()
+           )
+
+json_print(response)
+
+# multilingual query for vacation spots in California in Arabic
+response = (client.query
+            .get("Wikipedia",['text','title','url','views','lang'])
+            .with_near_text({"concepts": "أماكن العطلات في كاليفورنيا"})
+            .with_where({
+                "path" : ['lang'],
+                "operator" : "Equal",
+                "valueString":'en'
+            })
+            .with_limit(3)
+            .do()
+           )
+
+json_print(response)
+
+# rag is being used to generate a Facebook ad using the Wikipedia data
+prompt = "Write me a facebook ad about {title} using information inside {text}"
+result = (
+  client.query
+  .get("Wikipedia", ["title","text"])
+  .with_generate(single_prompt=prompt)
+  .with_near_text({
+    "concepts": ["Vacation spots in california"]
+  })
+  .with_limit(3)
+).do()
+
+json_print(result)
+
+generate_prompt = "Summarize what these posts are about in two paragraphs."
+ # Use a single prompt to summarize all posts
+result = (
+  client.query
+  .get("Wikipedia", ["title","text"])
+  .with_generate(grouped_task=generate_prompt) # Pass in all objects at once
+  .with_near_text({
+    "concepts": ["Vacation spots in california"]
+  })
+  .with_limit(3)
+).do()
+
+json_print(result)


### PR DESCRIPTION
`Multilingual RAG` - Example of RAG (Retrieval Augmented Generation) by combining a VectorDB (Weaviate) for information retrieval with a generative AI model for text generation.
 - Queries are performed on a vectorized collection of Wikipedia articles.
 - The `.with_near_text()` method retrieves relevant documents based on semantic similarity to a query (e.g., "Vacation spots in California").
 - The retrieved data is passed to a generative AI model (OpenAI) to create new content.
 - The `.with_generate()` method is used to generate text based on the retrieved documents:
    - Single Prompt Generation: A Facebook ad is generated using the retrieved article's title and text.
    RAG combines retrieval (from a knowledge base) with generation (using a language model). This approach enhances the generative model's output by grounding it in factual, retrieved data, making it more accurate and contextually relevant. In this code:

      `Weaviate` handles the retrieval.
      `OpenAI`'s generative model handles the generation.
      The `.with_generate()` method bridges the two, making this a RAG implementation.